### PR TITLE
Add Android TV login flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -199,6 +199,19 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".tv.CameraAreaActivity"
+            android:exported="true"
+            android:theme="@style/Theme.HomeAssistant">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".tv.CameraPiPActivity"
+            android:supportsPictureInPicture="true"
+            android:exported="false"
+            android:theme="@style/Theme.HomeAssistant" />
         <activity android:name=".widgets.common.WidgetAuthenticationActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
@@ -289,10 +302,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
 
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -168,6 +168,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND_HIGH_ACCURACY_MODE = "command_high_accuracy_mode"
         const val COMMAND_ACTIVITY = "command_activity"
         const val COMMAND_WEBVIEW = "command_webview"
+        const val COMMAND_CAMERA_PIP = "command_camera_pip"
         const val COMMAND_KEEP_SCREEN_ON = "keep_screen_on"
         const val COMMAND_LAUNCH_APP = "command_launch_app"
         const val COMMAND_APP_LOCK = "command_app_lock"
@@ -176,6 +177,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND_SCREEN_BRIGHTNESS_LEVEL = "command_screen_brightness_level"
         const val COMMAND_SCREEN_OFF_TIMEOUT = "command_screen_off_timeout"
         const val COMMAND_FLASHLIGHT = "command_flashlight"
+        const val CAMERA_PATH = "camera_path"
 
         // DND commands
         const val DND_PRIORITY_ONLY = "priority_only"
@@ -231,7 +233,8 @@ class MessagingManager @Inject constructor(
             COMMAND_AUTO_SCREEN_BRIGHTNESS,
             COMMAND_SCREEN_BRIGHTNESS_LEVEL,
             COMMAND_SCREEN_OFF_TIMEOUT,
-            COMMAND_FLASHLIGHT
+            COMMAND_FLASHLIGHT,
+            COMMAND_CAMERA_PIP
         )
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
@@ -466,6 +469,16 @@ class MessagingManager @Inject constructor(
                         }
                         COMMAND_WEBVIEW -> {
                             handleDeviceCommands(jsonData)
+                        }
+                        COMMAND_CAMERA_PIP -> {
+                            if (!jsonData[CAMERA_PATH].isNullOrEmpty()) {
+                                handleDeviceCommands(jsonData)
+                            } else {
+                                Timber.d(
+                                    "Missing camera path for PiP, posting notification to device"
+                                )
+                                sendNotification(jsonData)
+                            }
                         }
                         COMMAND_SCREEN_ON -> {
                             handleDeviceCommands(jsonData)
@@ -730,6 +743,9 @@ class MessagingManager @Inject constructor(
                 } else {
                     openWebview(command, data)
                 }
+            }
+            COMMAND_CAMERA_PIP -> {
+                openCameraPip(data)
             }
             COMMAND_SCREEN_ON -> {
                 if (!command.isNullOrEmpty()) {
@@ -1855,6 +1871,20 @@ class MessagingManager @Inject constructor(
             context.startActivity(intent)
         } catch (e: Exception) {
             Timber.e(e, "Unable to open webview")
+        }
+    }
+
+    private fun openCameraPip(data: Map<String, String>) {
+        try {
+            val serverId = data[THIS_SERVER_ID]!!.toInt()
+            val path = data[CAMERA_PATH]
+            val intent = CameraPiPActivity.newInstance(context, path, serverId)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Timber.e(e, "Unable to open camera pip")
         }
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraAreaActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraAreaActivity.kt
@@ -1,0 +1,144 @@
+package io.homeassistant.companion.android.tv
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.BaseActivity
+import io.homeassistant.companion.android.BuildConfig
+import io.homeassistant.companion.android.common.data.authentication.SessionState
+import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
+import io.homeassistant.companion.android.common.data.servers.Server
+import io.homeassistant.companion.android.common.data.servers.ServerConnectionInfo
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.servers.ServerSessionInfo
+import io.homeassistant.companion.android.common.data.servers.ServerType
+import io.homeassistant.companion.android.common.data.servers.ServerUserInfo
+import io.homeassistant.companion.android.database.sensor.SensorDao
+import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import io.homeassistant.companion.android.onboarding.OnboardApp
+import io.homeassistant.companion.android.onboarding.getMessagingToken
+import io.homeassistant.companion.android.sensors.LocationSensorManager
+import io.homeassistant.companion.android.settings.SettingViewModel
+import io.homeassistant.companion.android.tv.views.CameraAreaView
+import io.homeassistant.companion.android.util.UrlUtil
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+class CameraAreaActivity : BaseActivity() {
+
+    private val viewModel: CameraAreaViewModel by viewModels()
+
+    @Inject
+    lateinit var serverManager: ServerManager
+
+    @Inject
+    lateinit var sensorDao: SensorDao
+
+    private val settingViewModel: SettingViewModel by viewModels()
+
+    private val registerActivityResult = registerForActivityResult(
+        OnboardApp()
+    ) { result ->
+        onOnboardingComplete(result)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (isAuthenticated()) {
+            setContent { CameraAreaView(viewModel) }
+        } else {
+            registerActivityResult.launch(OnboardApp.Input())
+        }
+    }
+
+    private fun isAuthenticated(): Boolean {
+        return try {
+            serverManager.isRegistered() &&
+                serverManager.authenticationRepository().getSessionState() == SessionState.CONNECTED
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun onOnboardingComplete(result: OnboardApp.Output?) {
+        if (result == null) {
+            finish()
+            return
+        }
+
+        lifecycleScope.launch {
+            registerServer(result)
+            setContent { CameraAreaView(viewModel) }
+        }
+    }
+
+    private suspend fun registerServer(result: OnboardApp.Output) {
+        var serverId: Int? = null
+        try {
+            val (url, authCode, deviceName, deviceTrackingEnabled, notificationsEnabled) = result
+            val messagingToken = getMessagingToken()
+            val formattedUrl = UrlUtil.formattedUrlString(url)
+            val server = Server(
+                _name = "",
+                type = ServerType.TEMPORARY,
+                connection = ServerConnectionInfo(
+                    externalUrl = formattedUrl
+                ),
+                session = ServerSessionInfo(),
+                user = ServerUserInfo()
+            )
+            serverId = serverManager.addServer(server)
+            serverManager.authenticationRepository(serverId).registerAuthorizationCode(authCode)
+            serverManager.integrationRepository(serverId).registerDevice(
+                DeviceRegistration(
+                    "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                    deviceName,
+                    messagingToken
+                )
+            )
+            serverId = serverManager.convertTemporaryServer(serverId)
+        } catch (e: Exception) {
+            Timber.e(e, "Exception while registering")
+            try {
+                if (serverId != null) {
+                    serverManager.authenticationRepository(serverId).revokeSession()
+                    serverManager.removeServer(serverId)
+                }
+            } catch (e2: Exception) {
+                Timber.e(e2, "Can't revoke session")
+            }
+            return
+        }
+        serverId?.let {
+            setLocationTracking(it, result.deviceTrackingEnabled)
+            setNotifications(it, result.notificationsEnabled)
+        }
+    }
+
+    private suspend fun setLocationTracking(serverId: Int, enabled: Boolean) {
+        sensorDao.setSensorsEnabled(
+            sensorIds = listOf(
+                LocationSensorManager.backgroundLocation.id,
+                LocationSensorManager.zoneLocation.id,
+                LocationSensorManager.singleAccurateLocation.id
+            ),
+            serverId = serverId,
+            enabled = enabled
+        )
+    }
+
+    private fun setNotifications(serverId: Int, enabled: Boolean) {
+        if (BuildConfig.FLAVOR != "full") {
+            settingViewModel.getSetting(serverId)
+            settingViewModel.updateWebsocketSetting(
+                serverId,
+                if (enabled) WebsocketSetting.ALWAYS else WebsocketSetting.NEVER
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraAreaViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraAreaViewModel.kt
@@ -1,0 +1,63 @@
+package io.homeassistant.companion.android.tv
+
+import android.app.Application
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.util.RegistriesDataHandler
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class CameraAreaViewModel @Inject constructor(
+    private val serverManager: ServerManager,
+    application: Application
+) : AndroidViewModel(application) {
+
+    var areas = mutableStateOf<List<AreaRegistryResponse>>(emptyList())
+        private set
+    var camerasByArea = mutableStateMapOf<String?, List<Entity>>()
+        private set
+    var isLoading = mutableStateOf(true)
+        private set
+
+    init {
+        loadData()
+    }
+
+    fun loadData() {
+        viewModelScope.launch {
+            isLoading.value = true
+            try {
+                val ws = serverManager.webSocketRepository()
+                val integrationRepo = serverManager.integrationRepository()
+                val areaRegistry = ws.getAreaRegistry().orEmpty().sortedBy { it.name }
+                val deviceRegistry = ws.getDeviceRegistry()
+                val entityRegistry = ws.getEntityRegistry()
+                val entities = integrationRepo.getEntities().orEmpty()
+                    .filter { it.entityId.startsWith("camera.") }
+                areas.value = areaRegistry
+                camerasByArea.clear()
+                for (entity in entities) {
+                    val area = RegistriesDataHandler.getAreaForEntity(
+                        entity.entityId,
+                        areaRegistry,
+                        deviceRegistry,
+                        entityRegistry
+                    )
+                    val key = area?.areaId
+                    val list = camerasByArea[key]?.toMutableList() ?: mutableListOf()
+                    list.add(entity)
+                    camerasByArea[key] = list
+                }
+            } finally {
+                isLoading.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraPiPActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/tv/CameraPiPActivity.kt
@@ -1,0 +1,34 @@
+package io.homeassistant.companion.android.tv
+
+import android.app.PictureInPictureParams
+import android.graphics.Rect
+import android.os.Build
+import android.os.Bundle
+import android.util.Rational
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.webview.WebViewActivity
+import android.content.Context
+import android.content.Intent
+
+@AndroidEntryPoint
+class CameraPiPActivity : WebViewActivity() {
+
+    companion object {
+        fun newInstance(context: Context, path: String?, serverId: Int): Intent {
+            return WebViewActivity.newInstance(context, path, serverId).setClass(context, CameraPiPActivity::class.java)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val bounds = Rect(0, 0, 1920, 1080)
+            enterPictureInPictureMode(
+                PictureInPictureParams.Builder()
+                    .setAspectRatio(Rational(bounds.width(), bounds.height()))
+                    .setSourceRectHint(bounds)
+                    .build()
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/tv/views/CameraAreaView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/tv/views/CameraAreaView.kt
@@ -1,0 +1,67 @@
+package io.homeassistant.companion.android.tv.views
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.tv.CameraAreaViewModel
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+
+@Composable
+fun CameraAreaView(viewModel: CameraAreaViewModel) {
+    HomeAssistantAppTheme {
+        if (viewModel.isLoading.value) {
+            CircularProgressIndicator(modifier = Modifier.fillMaxSize().padding(32.dp))
+        } else {
+            val areas = viewModel.areas.value
+            LazyColumn(contentPadding = PaddingValues(16.dp)) {
+                areas.forEach { area ->
+                    val cameras = viewModel.camerasByArea[area.areaId].orEmpty()
+                    if (cameras.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = area.name,
+                                style = MaterialTheme.typography.h6,
+                                modifier = Modifier.padding(vertical = 8.dp)
+                            )
+                        }
+                        items(cameras) { camera ->
+                            CameraRow(camera)
+                        }
+                    }
+                }
+                val noAreaCameras = viewModel.camerasByArea[null].orEmpty()
+                if (noAreaCameras.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(id = R.string.no_area),
+                            style = MaterialTheme.typography.h6,
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    }
+                    items(noAreaCameras) { camera ->
+                        CameraRow(camera)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CameraRow(camera: Entity) {
+    Text(
+        text = camera.friendlyName,
+        modifier = Modifier.padding(start = 16.dp, bottom = 4.dp)
+    )
+}

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1380,4 +1380,6 @@
     <string name="thermostat_tile">Thermostat tile</string>
     <string name="climate_heating">Heating</string>
     <string name="climate_cooling">Cooling</string>
+    <string name="no_area">No area</string>
+    <string name="camera_by_area">Cameras by area</string>
 </resources>


### PR DESCRIPTION
## Summary
- make CameraAreaActivity start onboarding when not authenticated
- register server and start camera area view after onboarding
- remove leanback launcher from LaunchActivity so only the TV activity is shown

## Testing
- `./gradlew tasks --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_684d219bdd848329ae8f5bb625fd1a06